### PR TITLE
Fix script compile.rb fails with NoMethodError, #4

### DIFF
--- a/other/compile.rb
+++ b/other/compile.rb
@@ -62,7 +62,7 @@ begin
       print "#{dep} has been compiled\n"
       print "#{total} remained\n"
       print "------------------------\n"
-      if dep.starts_with?("python")
+      if dep.start_with?("python")
         patch_python
       end
     end


### PR DESCRIPTION
Correct spelling of method 'start_with'.