### PR TITLE
Fix patch fails applied to mpv 0.33.1, #12

### DIFF
--- a/other/mpv.patch
+++ b/other/mpv.patch
@@ -1,5 +1,18 @@
+diff --git a/demux/demux_lavf.c b/demux/demux_lavf.c
+index 1bc8699e15..2c69de447c 100644
+--- a/demux/demux_lavf.c
++++ b/demux/demux_lavf.c
+@@ -1354,6 +1354,8 @@ static void demux_close_lavf(demuxer_t *demuxer)
+         }
+         if (priv->own_stream)
+             free_stream(priv->stream);
++        if (priv->av_opts)
++            av_dict_free(&priv->av_opts);
+         talloc_free(priv);
+         demuxer->priv = NULL;
+     }
 diff --git a/version.sh b/version.sh
-index 2cfc384b5c..6a2c049bfe 100755
+index dd896e2e4a..3e2d508bd4 100755
 --- a/version.sh
 +++ b/version.sh
 @@ -34,7 +34,7 @@ fi
@@ -12,23 +25,26 @@ index 2cfc384b5c..6a2c049bfe 100755
  
  # other tarballs extract the version number from the VERSION file
 diff --git a/waftools/detections/compiler_swift.py b/waftools/detections/compiler_swift.py
-index cf55149291..9efef4c4d9 100644
+index be66df0fbe..b3a2a706b9 100644
 --- a/waftools/detections/compiler_swift.py
 +++ b/waftools/detections/compiler_swift.py
-@@ -24,13 +24,13 @@ def __add_swift_flags(ctx):
- def __add_swift_library_linking_flags(ctx, swift_library):
+@@ -36,7 +36,7 @@ def __add_swift_flags(ctx):
+ def __add_static_swift_library_linking_flags(ctx, swift_library):
      ctx.env.append_value('LINKFLAGS', [
          '-L%s' % swift_library,
 -        '-Xlinker', '-force_load_swift_libs', '-lc++',
 +        '-lc++',
      ])
  
- def __find_swift_library(ctx):
-     swift_library_paths = [
--        'Toolchains/XcodeDefault.xctoolchain/usr/lib/swift_static/macosx',
--        'usr/lib/swift_static/macosx'
-+        'Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx',
-+        'usr/lib/swift/macosx'
-     ]
-     dev_path = __run(['xcode-select', '-p'])[1:]
  
+@@ -83,8 +83,8 @@ def __find_swift_library(ctx):
+             'usr/lib/swift/macosx'
+         ],
+         'SWIFT_LIB_STATIC': [
+-            'Toolchains/XcodeDefault.xctoolchain/usr/lib/swift_static/macosx',
+-            'usr/lib/swift_static/macosx'
++            'Toolchains/XcodeDefault.xctoolchain/usr/lib/static/macosx',
++            'usr/lib/static/macosx'
+         ]
+     }
+     dev_path = __run(['xcode-select', '-p'])[1:]


### PR DESCRIPTION
This commit will update the patch file `mpv.patch` to successfully apply
against mpv 0.33.1.

This also adds a two line patch to fix a memory leak in mpv responsible
for IINA issue iina#3460.