### PR TITLE
Update compile.rb to be compatible with homebrew 4.0 and rubberband

### DIFF
--- a/ffmpeg-iina.rb
+++ b/ffmpeg-iina.rb
@@ -26,7 +26,7 @@ EOS
   depends_on "rubberband"
   depends_on "snappy"
   depends_on "speex"
-  depends_on "tesseract"
+  # depends_on "tesseract"
   depends_on "xz"
   depends_on "zeromq"
   depends_on "zimg"
@@ -58,7 +58,7 @@ EOS
       --enable-libdav1d
       --enable-librubberband
       --enable-libsnappy
-      --enable-libtesseract
+      --disable-libtesseract
       --enable-libvidstab
       --enable-libxml2
       --enable-libfontconfig


### PR DESCRIPTION
Still testing, don't merge yet.

- Runs `brew update --auto-update` and `brew livecheck` to make sure local taps are updated
- **Sets `HOMEBREW_NO_INSTALL_FROM_API` to install from local taps**
- Uses `brew fetch -f` to prevent installing from outdated local source cache
- Patches `rubberband` to add `mmacosx-version-min=10.11` to `-Dcpp_args`. Otherwise, rubberband's [meson build script](https://github.com/breakfastquay/rubberband/blob/b04b731a954fab2cdbe18e11b372a6d0f4114387/meson.build#L443) will override it.

We may need to consider maintaining additional taps for the libs we patched, because Homebrew now obviously discourages editing core taps.