### PR TITLE
Change ffmpeg-iina compiler to gcc if Mac is Apple Silicon

### DIFF
--- a/ffmpeg-iina.rb
+++ b/ffmpeg-iina.rb
@@ -48,7 +48,6 @@ EOS
       --enable-shared
       --enable-pthreads
       --enable-version3
-      --cc=#{ENV.cc}
       --host-cflags=#{ENV.cflags}
       --host-ldflags=#{ENV.ldflags}
       --enable-ffplay
@@ -76,7 +75,8 @@ EOS
       --disable-programs
     ]
 
-    args << "--enable-neon" if Hardware::CPU.arm?
+    args << "--enable-neon --cc=gcc" if Hardware::CPU.arm?
+    args << "--cc=#{ENV.cc}" if Hardware::CPU.intel?
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
This solves issue #19 and allows ffmpeg-iina to be installed correctly on Apple Silicon.